### PR TITLE
Add Explicit Chalk Dependency & Build Script

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "release:stable": "dripip stable",
     "release:preview": "dripip preview",
     "release:pr": "dripip pr",
-    "prepublishOnly": "yarn build"
+    "prepublishOnly": "yarn build",
+    "prepare": "tsc -p tsconfig.cjs.json && tsc -p tsconfig.esm.json"
   },
   "devDependencies": {
     "@prisma-labs/prettier-config": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "typescript-snapshots-plugin": "1.7.0"
   },
   "dependencies": {
+    "chalk": "4",
     "fp-ts": "^2.11.3",
     "kleur": "^4.1.4",
     "lodash": "^4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1309,6 +1309,14 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
+chalk@4, chalk@^4.0.0, chalk@^4.1.0:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chalk@^2.0.0, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -1317,14 +1325,6 @@ chalk@^2.0.0, chalk@^2.4.2:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
-
-chalk@^4.0.0, chalk@^4.1.0:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
-  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
 
 char-regex@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This PR does two things
1. Adds an explicit dependency on Chalk as otherwise certain package managers would incorrectly link the wrong version and as a result, Floggy wouldn't work
2. Add the build script to a "prepare" script to allow installing this package directly from Github. This is because otherwise Yarn/NPM don't know what to run to build the package when installing directly from the repo.